### PR TITLE
feat(foundry): use containerEnv to set PATH

### DIFF
--- a/src/foundry/devcontainer-feature.json
+++ b/src/foundry/devcontainer-feature.json
@@ -1,8 +1,11 @@
 {
   "name": "Foundry",
   "id": "foundry",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A feature to install Foundry (Ethereum application development toolkit) via Foundry's own foundryup command.",
+  "containerEnv": {
+    "PATH": "/usr/local/share/foundry/bin:$PATH"
+  },
   "options": {
     "version": {
       "type": "string",

--- a/src/foundry/devcontainer-feature.json
+++ b/src/foundry/devcontainer-feature.json
@@ -1,19 +1,15 @@
 {
-    "name": "Foundry",
-    "id": "foundry",
-    "version": "1.0.0",
-    "description": "A feature to install Foundry (Ethereum application development toolkit) via Foundry's own foundryup command.",
-    "options": {
-        "version": {
-            "type": "string",
-            "proposals": [
-                "nightly"
-            ],
-            "default": "",
-            "description": "The specific version to install (foundryup --version $VERSION)"
-        }
-    },
-    "installsAfter": [
-        "ghcr.io/devcontainers/features/common-utils"
-    ]
+  "name": "Foundry",
+  "id": "foundry",
+  "version": "1.0.0",
+  "description": "A feature to install Foundry (Ethereum application development toolkit) via Foundry's own foundryup command.",
+  "options": {
+    "version": {
+      "type": "string",
+      "proposals": ["nightly"],
+      "default": "",
+      "description": "The specific version to install (foundryup --version $VERSION)"
+    }
+  },
+  "installsAfter": ["ghcr.io/devcontainers/features/common-utils"]
 }

--- a/src/foundry/install.bash
+++ b/src/foundry/install.bash
@@ -24,19 +24,10 @@ chmod +x $BIN_PATH
 # Create the man directory for future man files if it doesn't exist.
 mkdir -p $FOUNDRY_MAN_DIR
 
-# Add foundry to PATH & MANPATH
-cat > /etc/profile.d/50-foundry.sh \
-<< EOF
-export PATH="${FOUNDRY_BIN_DIR:?}:\$PATH"
-EOF
-
 # Add the foundry manpages to the MANPATH
 if [[ -e /etc/manpath.config ]]; then
  echo "MANDATORY_MANPATH $FOUNDRY_ROOT_MAN_DIR" >> /etc/manpath.config
 fi
-
-# Install foundry via foundryup
-source /etc/profile.d/50-foundry.sh
 
 INSTALL_ARGS=()
 if [[ "$VERSION" != "" ]]; then
@@ -45,4 +36,3 @@ if [[ "$VERSION" != "" ]]; then
 fi
 
 foundryup "${INSTALL_ARGS[@]}"
-


### PR DESCRIPTION
Rather than creating a `/etc/profile.d` file, we now set the `PATH` environment variable directly on the container image layer, via the `"containerEnv"` option.

This should work more consistently, as `/etc/profile[.d]` is not necessarily sourced by devcontainer shells.